### PR TITLE
Make footer always be at the bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
           <li class="list-inline-item text-dark-violet"><i class="fab fa-facebook fa-lg"></i></li>
           <li class="list-inline-item text-dark-violet"><i class="fab fa-twitter fa-lg"></i></li>
           <li class="list-inline-item text-dark-violet"><i class="fab fa-instagram fa-lg"></i></li>
+          <li class="list-inline-item text-dark-violet"><a class="text-dark-violet" target="_blank" href="https://github.com/frontendcafe/cmyk-grape"><i class="fab fa-github fa-lg"></i></a></li>
         </ul>
       </div>
 

--- a/public/css/footer.css
+++ b/public/css/footer.css
@@ -1,5 +1,6 @@
 .footer {
     height: 70px;
+    position: fixed;
     bottom: 0;
     margin-top: 1em;
 }

--- a/public/css/footer.css
+++ b/public/css/footer.css
@@ -1,6 +1,6 @@
 .footer {
     height: 70px;
-    position: fixed;
+    position: relative;
     bottom: 0;
     margin-top: 1em;
 }

--- a/public/views/actividades.html
+++ b/public/views/actividades.html
@@ -75,6 +75,7 @@
           <li class="list-inline-item text-dark-violet"><i class="fab fa-facebook fa-lg"></i></li>
           <li class="list-inline-item text-dark-violet"><i class="fab fa-twitter fa-lg"></i></li>
           <li class="list-inline-item text-dark-violet"><i class="fab fa-instagram fa-lg"></i></li>
+          <li class="list-inline-item text-dark-violet"><a class="text-dark-violet" target="_blank" href="https://github.com/frontendcafe/cmyk-grape"><i class="fab fa-github fa-lg"></i></a></li>
         </ul>
       </div>
   

--- a/public/views/contact.html
+++ b/public/views/contact.html
@@ -104,6 +104,7 @@
                 <li class="list-inline-item text-dark-violet"><i class="fab fa-facebook fa-lg"></i></li>
                 <li class="list-inline-item text-dark-violet"><i class="fab fa-twitter fa-lg"></i></li>
                 <li class="list-inline-item text-dark-violet"><i class="fab fa-instagram fa-lg"></i></li>
+                <li class="list-inline-item text-dark-violet"><a class="text-dark-violet" target="_blank" href="https://github.com/frontendcafe/cmyk-grape"><i class="fab fa-github fa-lg"></i></a></li>
             </ul>
         </div>
 

--- a/public/views/museum.html
+++ b/public/views/museum.html
@@ -116,6 +116,7 @@
         <li class="list-inline-item text-dark-violet"><i class="fab fa-facebook fa-lg"></i></li>
         <li class="list-inline-item text-dark-violet"><i class="fab fa-twitter fa-lg"></i></li>
         <li class="list-inline-item text-dark-violet"><i class="fab fa-instagram fa-lg"></i></li>
+        <li class="list-inline-item text-dark-violet"><a class="text-dark-violet" target="_blank" href="https://github.com/frontendcafe/cmyk-grape"><i class="fab fa-github fa-lg"></i></a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
In resolutions with a lot of height the footer did not stand at the bottom of the page.
Used position: fixed; bottom 0 was already there.
Tested also with mobile.